### PR TITLE
Upgrade debug to version 2.6.9

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "body-parser": "~1.13.2",
     "cookie-parser": "~1.3.5",
-    "debug": "~2.2.0",
+    "debug": "~2.6.9",
     "express": "~4.13.1",
     "jade": "~1.11.0",
     "jsonwebtoken": "^5.7.0",


### PR DESCRIPTION
low severity
Vulnerable versions: < 2.6.9
Patched version: 2.6.9
The debug module is vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter. It takes around 50k characters to block for 2 seconds making this a low severity issue.